### PR TITLE
chore: renamed exec to whip-mpegts and added install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeFiles/
 Makefile
 cmake_install.cmake
 mpeg-ts-client
+whip-mpegts
 CMakeScripts/
 build/
 mpeg-ts-client.build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16.0)
-project(mpeg-ts-client)
+project(whip-mpegts)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -38,7 +38,7 @@ set(FILES
         utils/ScopedGLibMem.h
         Logger.cpp)
 
-add_executable(mpeg-ts-client ${FILES})
+add_executable(whip-mpegts ${FILES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
         ${PROJECT_SOURCE_DIR}
@@ -54,3 +54,5 @@ target_link_libraries(${PROJECT_NAME}
         ${GSTREAMER_WEBRTC_LDFLAGS}
         ${GSTREAMER_SDP_LDFLAGS}
         ${SOUP_LDFLAGS})
+
+install(TARGETS whip-mpegts DESTINATION bin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN apt-get update
 RUN apt-get -y install libgstreamer1.0-0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-libav gstreamer1.0-plugins-rtp gstreamer1.0-nice libsoup2.4-1 gstreamer1.0-tools
 
 WORKDIR /app
-COPY --from=0 /src/mpeg-ts-client ./mpeg-ts-client
+COPY --from=0 /src/whip-mpegts ./whip-mpegts
 
-ENTRYPOINT ["./mpeg-ts-client"]
+ENTRYPOINT ["./whip-mpegts"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ make
 
 Run:
 ```
-./mpeg-ts-client -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key]
+./whip-mpegts -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key]
 ```
 
 ### OSX
@@ -47,7 +47,7 @@ make
 Run:
 ```
 export GST_PLUGIN_PATH=/usr/local/lib/gstreamer-1.0/
-./mpeg-ts-client -a <MPEG-TS address> -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key]
+./whip-mpegts -a <MPEG-TS address> -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key]
 ```
 
 ### Docker Container


### PR DESCRIPTION
In preparation for building a homebrew formulae I renamed the executable to `whip-mpegts` and added a `make install` target. I found that `mpeg-ts-client` to be a bit to general in a system-wide installation context.