### PR TITLE
feat: support for receiving MPEGTS over SRT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,10 @@ CMakeScripts/
 build/
 mpeg-ts-client.build/
 mpeg-ts-client.xcodeproj/
-.vscode
+## Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+## End Visual Studio Code

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [        
+        {
+            "name": "(lldb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/whip-mpegts",
+            "args": [ "-a", "127.0.0.1", 
+                      "-p", "1234",
+                      "-s", 
+                      "-u", "http://localhost:8200/api/v2/whip/sfu-broadcaster?channelId=test"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "chrono": "cpp"
+    }
+}

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -12,6 +12,7 @@
 #include <gst/gst.h>
 #include <gst/sdp/sdp.h>
 #include <gst/webrtc/webrtc.h>
+#include <ext/srt/gstsrtsrc.h>
 
 class Pipeline::Impl
 {
@@ -21,7 +22,8 @@ public:
         const uint32_t mpegTsPort,
         const std::chrono::milliseconds mpegTsBufferSize,
         const bool showWindow,
-        const bool showTimer);
+        const bool showTimer,
+        const bool srtTransport);
 
     Impl(http::WhipClient& whipClient, std::string&& fileName, const bool showWindow, const bool showTimer);
 
@@ -47,6 +49,7 @@ private:
     enum class ElementLabel
     {
         UDP_SOURCE,
+        SRT_SOURCE,
         UDP_QUEUE,
         TS_DEMUX,
 
@@ -98,6 +101,7 @@ private:
 
     bool showWindow_;
     bool showTimer_;
+    bool srtTransport_;
 
     void makeElement(const ElementLabel elementLabel, const char* name, const char* element);
     void onH264SinkPadAdded(GstPad* newPad);
@@ -111,33 +115,51 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
     const uint32_t mpegTsPort,
     const std::chrono::milliseconds mpegTsBufferSize,
     const bool showWindow,
-    const bool showTimer)
+    const bool showTimer,
+    const bool srtTransport)
     : pipelineMessageBus_(nullptr),
       whipClient_(whipClient),
       showWindow_(showWindow),
-      showTimer_(showTimer)
+      showTimer_(showTimer),
+      srtTransport_(srtTransport)
 {
-    Logger::log("Creating pipeline mpegTsAddress %s, mpegTsPort %u, mpegTsBufferSize %llu ns",
+    Logger::log("Creating pipeline mpegTsAddress %s, mpegTsPort %u, mpegTsBufferSize %llu ns, srt=%s",
         mpegTsAddress.c_str(),
         mpegTsPort,
-        std::chrono::nanoseconds(mpegTsBufferSize).count());
+        std::chrono::nanoseconds(mpegTsBufferSize).count(),
+        srtTransport_ ? "true" : "false");
 
     init();
 
     makeElement(ElementLabel::UDP_SOURCE, "UDP_SOURCE", "udpsrc");
+    makeElement(ElementLabel::SRT_SOURCE, "SRT_SOURCE", "srtsrc");
     makeElement(ElementLabel::UDP_QUEUE, "UDP_QUEUE", "queue");
     makeElement(ElementLabel::TS_DEMUX, "TS_DEMUX", "tsdemux");
 
-    if (!gst_element_link_many(elements_[ElementLabel::UDP_SOURCE],
+    if (!gst_element_link_many(
+            elements_[srtTransport_ ? ElementLabel::SRT_SOURCE : ElementLabel::UDP_SOURCE],
             elements_[ElementLabel::UDP_QUEUE],
             elements_[ElementLabel::TS_DEMUX],
             nullptr))
     {
-        g_printerr("UPD source elements could not be linked.\n");
+        g_printerr("UDP source elements could not be linked.\n");
         return;
     }
 
     g_signal_connect(elements_[ElementLabel::TS_DEMUX], "pad-added", G_CALLBACK(demuxPadAddedCallback), this);
+
+    g_object_set(elements_[ElementLabel::SRT_SOURCE],
+        "localaddress",
+        mpegTsAddress.c_str(),
+        "localport",
+        mpegTsPort,
+        "mode",
+        GST_SRT_CONNECTION_MODE_LISTENER,
+        "wait-for-connection",
+        true,
+        "latency",
+        125,
+        nullptr);
 
     g_object_set(elements_[ElementLabel::UDP_SOURCE],
         "address",
@@ -694,13 +716,15 @@ Pipeline::Pipeline(http::WhipClient& whipClient,
     const uint32_t mpegTsPort,
     const std::chrono::milliseconds mpegTsBufferSize,
     const bool showWindow,
-    const bool showTimer)
+    const bool showTimer,
+    const bool srtTransport)
     : impl_(std::make_unique<Pipeline::Impl>(whipClient,
           std::move(mpegTsAddress),
           mpegTsPort,
           mpegTsBufferSize,
           showWindow,
-          showTimer))
+          showTimer,
+          srtTransport))
 {
 }
 

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -149,6 +149,7 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
             elements_[ElementLabel::UDP_QUEUE]))
         {
             g_printerr("UDP transport elements could nt be linked.\n");
+            return;
         }
 
         g_object_set(elements_[ElementLabel::UDP_SOURCE],
@@ -168,6 +169,7 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
             elements_[ElementLabel::UDP_QUEUE]))
         {
             g_printerr("SRT transport elements could nt be linked.\n");
+            return;
         }
 
         g_object_set(elements_[ElementLabel::SRT_SOURCE],

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -148,7 +148,7 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
             elements_[ElementLabel::UDP_SOURCE],
             elements_[ElementLabel::UDP_QUEUE]))
         {
-            g_printerr("UDP transport elements could nt be linked.\n");
+            g_printerr("UDP transport elements could not be linked.\n");
             return;
         }
 
@@ -168,7 +168,7 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
             elements_[ElementLabel::SRT_SOURCE],
             elements_[ElementLabel::UDP_QUEUE]))
         {
-            g_printerr("SRT transport elements could nt be linked.\n");
+            g_printerr("SRT transport elements could not be linked.\n");
             return;
         }
 

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -12,7 +12,6 @@
 #include <gst/gst.h>
 #include <gst/sdp/sdp.h>
 #include <gst/webrtc/webrtc.h>
-#include <ext/srt/gstsrtsrc.h>
 
 class Pipeline::Impl
 {
@@ -148,29 +147,31 @@ Pipeline::Impl::Impl(http::WhipClient& whipClient,
 
     g_signal_connect(elements_[ElementLabel::TS_DEMUX], "pad-added", G_CALLBACK(demuxPadAddedCallback), this);
 
-    g_object_set(elements_[ElementLabel::SRT_SOURCE],
-        "localaddress",
-        mpegTsAddress.c_str(),
-        "localport",
-        mpegTsPort,
-        "mode",
-        GST_SRT_CONNECTION_MODE_LISTENER,
-        "wait-for-connection",
-        true,
-        "latency",
-        125,
-        nullptr);
-
-    g_object_set(elements_[ElementLabel::UDP_SOURCE],
-        "address",
-        mpegTsAddress.c_str(),
-        "port",
-        mpegTsPort,
-        "auto-multicast",
-        true,
-        "buffer-size",
-        825984,
-        nullptr);
+    if (srtTransport_) {
+        g_object_set(elements_[ElementLabel::SRT_SOURCE],
+            "localaddress",
+            mpegTsAddress.c_str(),
+            "localport",
+            mpegTsPort,
+            "mode",
+            2, // GST_SRT_CONNECTION_MODE_LISTENER,
+            "wait-for-connection",
+            true,
+            "latency",
+            125,
+            nullptr);
+    } else {
+        g_object_set(elements_[ElementLabel::UDP_SOURCE],
+            "address",
+            mpegTsAddress.c_str(),
+            "port",
+            mpegTsPort,
+            "auto-multicast",
+            true,
+            "buffer-size",
+            825984,
+            nullptr);
+    }
 
     g_object_set(elements_[ElementLabel::UDP_QUEUE],
         "min-threshold-time",

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -19,7 +19,8 @@ public:
         const uint32_t mpegTsPort,
         const std::chrono::milliseconds mpegTsBufferSize,
         const bool showWindow,
-        const bool showTimer);
+        const bool showTimer,
+        const bool srtTransport);
 
     Pipeline(http::WhipClient& whipClient, std::string&& fileName, const bool showWindow, const bool showTimer);
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Install additional dependencies using homebrew:
 brew install gstreamer gst-plugins-good gst-plugins-bad libsoup@2 cmake gst-libav
 ```
 
+On Apple M1 you might need to build the gst-plugins-bad from source as the SRT plugins are not available in the binary bottle.
+
+```
+brew reinstall --build-from-source gst-plugins-bad
+```
+
 Build:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MPEG-TS client for the WebRTC-HTTP ingestion protocol
 
-MPEG-TS ingestion client for WHIP (https://github.com/Eyevinn/whip). Ingests an MPEG-TS unicast or multicast stream and sends it to a WHIP endpoint.
+MPEG-TS ingestion client for WHIP (https://github.com/Eyevinn/whip). Ingests an MPEG-TS unicast or multicast or [SRT](https://srtalliance.org/) stream and sends it to a WHIP endpoint.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ make
 
 Run:
 ```
-./whip-mpegts -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key] -d [MPEG-TS buffer size ms] -f [mp4 file input] [-t] [-w]
+./whip-mpegts -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key] -d [MPEG-TS buffer size ms] -f [mp4 file input] [-t] [-w] [-s]
 ```
 
 Supplying a file with -f will override MPEG-TS settings, use either MPEG-TS or file input.
@@ -32,6 +32,7 @@ Flags:
 
 - \-t Enable burned in timer
 - \-w Open a local window displaying the video before transcoding for comparison
+- \-s Setup SRT socket in listener mode for receiving MPEG-TS
 
 ### OSX
 

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,7 @@ int32_t main(int32_t argc, char** argv)
     auto showWindow = false;
     auto srtTransport = false;
 
-    while ((getOptResult = getopt(argc, argv, "a:p:u:k:d:f:tw")) != -1)
+    while ((getOptResult = getopt(argc, argv, "a:p:u:k:d:f:tws")) != -1)
     {
         switch (getOptResult)
         {

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@ namespace
 
 const char* usageString =
     "Usage: whip-mpegts -a [MPEG-TS address] -p [MPEG-TS port] -f [mp4 input file] -u <WHIP endpoint URL> -k "
-    "[WHIP auth key] -d [MPEG-TS buffer size ms] [-t] [-w]";
+    "[WHIP auth key] -d [MPEG-TS buffer size ms] [-t] [-w] [-s]";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -46,6 +46,7 @@ int32_t main(int32_t argc, char** argv)
     std::string fileName;
     auto showTimer = false;
     auto showWindow = false;
+    auto srtTransport = false;
 
     while ((getOptResult = getopt(argc, argv, "a:p:u:k:d:f:tw")) != -1)
     {
@@ -75,6 +76,9 @@ int32_t main(int32_t argc, char** argv)
         case 'w':
             showWindow = true;
             break;
+        case 's':
+            srtTransport = true;
+            break;
         default:
             printf("%s\n", usageString);
             return 1;
@@ -101,7 +105,8 @@ int32_t main(int32_t argc, char** argv)
             mpegTsPort,
             mpegTsBufferSize,
             showWindow,
-            showTimer);
+            showTimer,
+            srtTransport);
     }
     pipeline->run();
 


### PR DESCRIPTION
This PR addresses #11 and adds support for receiving MPEGTS over SRT.

To setup an SRT socket instead of a normal UDP socket you specify `-s` to the command in addition to the address and port options.