### PR TITLE
feat: support restream the MPEG-TS source to an UDP/SRT ingest endpoint

### DIFF
--- a/Pipeline.h
+++ b/Pipeline.h
@@ -18,6 +18,8 @@ public:
         std::string&& mpegTsAddress,
         const uint32_t mpegTsPort,
         const std::chrono::milliseconds mpegTsBufferSize,
+        std::string&& restreamAddress,
+        const uint32_t restreamPort,
         const bool showWindow,
         const bool showTimer,
         const bool srtTransport);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew install eyevinn/tools/whip-mpegts
 ### Usage
 
 ```
-./whip-mpegts -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key] -d [MPEG-TS buffer size ms] -f [mp4 file input] [-t] [-w] [-s]
+./whip-mpegts -a [MPEG-TS address] -p <MPEG-TS port> -u <WHIP endpoint URL> -k [WHIP auth key] -d [MPEG-TS buffer size ms] -f [mp4 file input] -r [MPEG-TS restream address] -o [MPEG-TS restream port] [-t] [-w] [-s]
 ```
 
 Supplying a file with -f will override MPEG-TS settings, use either MPEG-TS or file input.
@@ -26,7 +26,7 @@ Flags:
 
 - \-t Enable burned in timer
 - \-w Open a local window displaying the video before transcoding for comparison
-- \-s Setup SRT socket in listener mode for receiving MPEG-TS
+- \-s Setup SRT socket in listener mode for receiving MPEG-TS and also use SRT when restreaming
 
 ### Build Ubuntu 21.10
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,9 @@ namespace
 
 const char* usageString =
     "Usage: whip-mpegts -a [MPEG-TS address] -p [MPEG-TS port] -f [mp4 input file] -u <WHIP endpoint URL> -k "
-    "[WHIP auth key] -d [MPEG-TS buffer size ms] [-t] [-w] [-s]";
+    "[WHIP auth key] -d [MPEG-TS buffer size ms] "
+    "-r [restream address] -o [restream port] "
+    "[-t] [-w] [-s]";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -40,7 +42,9 @@ int32_t main(int32_t argc, char** argv)
     std::string url;
     std::string authKey;
     std::string mpegTsAddress = "0.0.0.0";
+    std::string restreamAddress = "";
     uint32_t mpegTsPort = 0;
+    uint32_t restreamPort = 0;
     int32_t getOptResult;
     std::chrono::milliseconds mpegTsBufferSize(1000);
     std::string fileName;
@@ -48,7 +52,7 @@ int32_t main(int32_t argc, char** argv)
     auto showWindow = false;
     auto srtTransport = false;
 
-    while ((getOptResult = getopt(argc, argv, "a:p:u:k:d:f:tws")) != -1)
+    while ((getOptResult = getopt(argc, argv, "a:p:u:k:d:f:r:o:tws")) != -1)
     {
         switch (getOptResult)
         {
@@ -70,6 +74,12 @@ int32_t main(int32_t argc, char** argv)
         case 'f':
             fileName = optarg;
             break;
+        case 'r':
+            restreamAddress = optarg;
+            break;
+        case 'o':
+            restreamPort = std::strtoul(optarg, nullptr, 10);
+            break;
         case 't':
             showTimer = true;
             break;
@@ -90,6 +100,11 @@ int32_t main(int32_t argc, char** argv)
         printf("%s\n", usageString);
         return 1;
     }
+    if (!restreamAddress.empty() && restreamPort == 0)
+    {
+        printf("Missing restream port.\n%s\n", usageString);
+        return 1;
+    }
 
     mainLoop = g_main_loop_new(nullptr, FALSE);
 
@@ -104,6 +119,8 @@ int32_t main(int32_t argc, char** argv)
             std::move(mpegTsAddress),
             mpegTsPort,
             mpegTsBufferSize,
+            std::move(restreamAddress),
+            restreamPort,
             showWindow,
             showTimer,
             srtTransport);


### PR DESCRIPTION
This PR adds support for restreaming the MPEG-TS source to another UDP/SRT ingest endpoint in addition to a WHIP endpoint. To try it out:

Start WHIP/WHEP service
```
curl -SL https://github.com/Eyevinn/whip-whep/releases/download/v0.1.0/docker-compose.yml | docker-compose -f - up
```

Receive mpegs on port 9999 and play with ffplay
```
ffplay "srt://127.0.0.1:9999?mode=listener"
```

Start whip-mpegts to listen to receive a stream on port 9998 and restream to port 9999
```
./whip-mpegts -a 127.0.0.1 -p 9998 -u "http://localhost:8200/api/v2/whip/sfu-broadcaster?channelId=test" -r 127.0.0.1 -o 9999 -s
```

Generate the input stream
```
ffmpeg -re -i VINN.mp4 -acodec copy -vcodec copy -f mpegts srt://127.0.0.1:9998
```
