### PR TITLE
Feat/Out-of-sync for LiveKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ mpeg-ts-client.xcodeproj/
 !.vscode/launch.json
 !.vscode/extensions.json
 ## End Visual Studio Code
+.xmake/
+dot/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
         "chrono": "cpp"
-    }
+    },
+    "editor.formatOnSave": true
 }

--- a/Config.h
+++ b/Config.h
@@ -20,6 +20,7 @@ struct Config
           tsDemuxLatency_(0),
           jitterBufferLatency_(0),
           srtSourceLatency_(125),
+          h264encodeBitrate(200),
           audio_(true),
           video_(true)
     {
@@ -64,6 +65,9 @@ struct Config
         result.append("srtSourceLatency: ");
         result.append(std::to_string(srtSourceLatency_));
         result.append("\n");
+        result.append("h264encodeBitrate: ");
+        result.append(std::to_string(h264encodeBitrate));
+        result.append("\n");
         result.append("audio: ");
         result.append(audio_ ? "true" : "false");
         result.append("\n");
@@ -87,6 +91,7 @@ struct Config
     uint32_t tsDemuxLatency_;
     uint32_t jitterBufferLatency_;
     uint32_t srtSourceLatency_;
+    uint32_t h264encodeBitrate;
 
     bool audio_;
     bool video_;

--- a/Config.h
+++ b/Config.h
@@ -50,6 +50,9 @@ struct Config
         result.append("restreamPort: ");
         result.append(std::to_string(restreamPort_));
         result.append("\n");
+        result.append("h264encodeBitrate: ");
+        result.append(std::to_string(h264encodeBitrate));
+        result.append("\n");
         result.append("showTimer: ");
         result.append(showTimer_ ? "true" : "false");
         result.append("\n");
@@ -64,9 +67,6 @@ struct Config
         result.append("\n");
         result.append("srtSourceLatency: ");
         result.append(std::to_string(srtSourceLatency_));
-        result.append("\n");
-        result.append("h264encodeBitrate: ");
-        result.append(std::to_string(h264encodeBitrate));
         result.append("\n");
         result.append("audio: ");
         result.append(audio_ ? "true" : "false");

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get -y install libgstreamer1.0-0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-libav gstreamer1.0-plugins-rtp gstreamer1.0-nice libsoup2.4-1 cmake gcc g++ make gdb libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-bad1.0-dev libsoup2.4-dev
+RUN apt-get -y install libgstreamer1.0-0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-libav gstreamer1.0-plugins-rtp gstreamer1.0-plugins-ugly gstreamer1.0-nice libsoup2.4-1 cmake gcc g++ make gdb libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-bad1.0-dev libsoup2.4-dev
 
 WORKDIR /src
 ADD ./ /src
@@ -13,7 +13,7 @@ RUN make
 FROM debian:bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get -y install libgstreamer1.0-0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-libav gstreamer1.0-plugins-rtp gstreamer1.0-nice libsoup2.4-1 gstreamer1.0-tools
+RUN apt-get -y install libgstreamer1.0-0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-libav gstreamer1.0-plugins-rtp gstreamer1.0-plugins-ugly gstreamer1.0-nice libsoup2.4-1 gstreamer1.0-tools
 
 WORKDIR /app
 COPY --from=0 /src/whip-mpegts ./whip-mpegts

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -240,6 +240,7 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
 
     g_object_set(elements_[ElementLabel::TS_DEMUX], "latency", config.tsDemuxLatency_, nullptr);
     g_signal_connect(elements_[ElementLabel::TS_DEMUX], "pad-added", G_CALLBACK(demuxPadAddedCallback), this);
+    g_signal_connect(elements_[ElementLabel::TS_DEMUX], "no-more-pads", G_CALLBACK(demuxNoMorePadsCallback), this);
 
     g_object_set(elements_[ElementLabel::UDP_QUEUE],
         "min-threshold-time",
@@ -296,6 +297,12 @@ void Pipeline::onDemuxPadAdded(GstPad* newPad)
     {
         Logger::log("Unsupported MPEG-TS demux pad type %s", newPadType);
     }
+}
+
+void Pipeline::onDemuxNoMorePads()
+{
+    Logger::log("All pads created");
+    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline_), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
 }
 
 GstElement* Pipeline::addClockOverlay(GstElement* lastElement)
@@ -664,6 +671,12 @@ void Pipeline::demuxPadAddedCallback(GstElement* /*src*/, GstPad* newPad, gpoint
 {
     auto impl = reinterpret_cast<Pipeline*>(userData);
     impl->onDemuxPadAdded(newPad);
+}
+
+void Pipeline::demuxNoMorePadsCallback(GstElement* /*src*/, gpointer userData)
+{
+    auto impl = reinterpret_cast<Pipeline*>(userData);
+    impl->onDemuxNoMorePads();
 }
 
 void Pipeline::onOfferCreatedCallback(GstPromise* promise, gpointer userData)

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -30,8 +30,8 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
     makeElement(ElementLabel::MPEG2_PARSE, "mpegvideoparse");
     makeElement(ElementLabel::MPEG2_DECODE, "avdec_mpeg2video");
 
-    makeElement(ElementLabel::RTP_VIDEO_ENCODE, "vp8enc");
-    makeElement(ElementLabel::RTP_VIDEO_PAYLOAD, "rtpvp8pay");
+    makeElement(ElementLabel::RTP_VIDEO_ENCODE, "x264enc");
+    makeElement(ElementLabel::RTP_VIDEO_PAYLOAD, "rtph264pay");
     makeElement(ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE, "queue");
     makeElement(ElementLabel::RTP_VIDEO_FILTER, "capsfilter");
 
@@ -62,14 +62,12 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
     g_object_set(elements_[ElementLabel::RTP_VIDEO_ENCODE],
         "threads",
         2,
-        "target-bitrate",
-        256000000,
-        "error-resilient",
-        1,
-        "end-usage",
-        0,
-        "deadline",
-        1,
+        "bitrate",
+        config.h264encodeBitrate,
+        "tune",
+        1, // zerolatency
+        "speed-preset",
+        1, // ultrafast
         nullptr);
 
     if (config.audio_)
@@ -102,7 +100,7 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
             96,
             "encoding-name",
             G_TYPE_STRING,
-            "VP8",
+            "H264",
             nullptr));
 
         gst_element_link_filtered(elements_[ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE],

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -25,12 +25,14 @@ public:
     void stop();
 
     void onDemuxPadAdded(GstPad* newPad);
+    void onDemuxNoMorePads();
     void onOfferCreated(GstPromise* promise);
     void onNegotiationNeeded();
     void onIceCandidate(guint mLineIndex, gchar* candidate);
 
     static gboolean pipelineBusWatch(GstBus* /*bus*/, GstMessage* message, gpointer userData);
     static void demuxPadAddedCallback(GstElement* /*src*/, GstPad* newPad, gpointer userData);
+    static void demuxNoMorePadsCallback(GstElement* /*src*/, gpointer userData);
     static void onOfferCreatedCallback(GstPromise* promise, gpointer userData);
     static void onNegotiationNeededCallback(GstElement* /*webRtcBin*/, gpointer userData);
     static void onIceCandidateCallback(GstElement* /*webrtc*/, guint mLineIndex, gchar* candidate, gpointer userData);

--- a/main.cpp
+++ b/main.cpp
@@ -23,12 +23,12 @@ namespace
     {"tsDemuxLatency", required_argument, nullptr, 0},
     {"jitterBufferLatency", required_argument, nullptr, 0},
     {"srtSourceLatency", required_argument, nullptr, 0},
-    {"h264EncodeBitrate", required_argument, nullptr, 0},
+    {"h264EncodeBitrate", required_argument, nullptr, 'b'},
     {"no-audio", no_argument, nullptr, 0},
     {"no-video", no_argument, nullptr, 0},
     {nullptr, no_argument, nullptr, 0}};
 
-const auto shortOptions = "a:p:u:k:d:r:o:ts";
+const auto shortOptions = "a:p:u:k:d:r:o:b:ts";
 
 const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  -a, --udpSourceAddress STRING\n"
@@ -38,12 +38,12 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  -d, --udpSourceQueueMinTime INT ms\n"
                           "  -r, --restreamAddress STRING\n"
                           "  -o, --restreamPort INT\n"
+                          "  -b, --h264EncodeBitrate INT (Kb)\n"
                           "  -t, --showTimer\n"
                           "  -s, --srtTransport\n"
                           "  --tsDemuxLatency INT\n"
                           "  --jitterBufferLatency INT\n"
                           "  --srtSourceLatency INT\n"
-                          "  --h264EncodeBitrate INT (Kb)\n"
                           "  --no-audio\n"
                           "  --no-video\n";
 
@@ -100,6 +100,9 @@ int32_t main(int32_t argc, char** argv)
         case 'o':
             config.restreamPort_ = std::strtoul(optarg, nullptr, 10);
             break;
+        case 'b':
+            config.h264encodeBitrate = std::strtoul(optarg, nullptr, 10);
+            break;
         case 't':
             config.showTimer_ = true;
             break;
@@ -124,12 +127,9 @@ int32_t main(int32_t argc, char** argv)
             config.srtSourceLatency_ = std::strtoul(optarg, nullptr, 10);
             break;
         case 12:
-            config.h264encodeBitrate = std::strtoul(optarg, nullptr, 10);
-            break;
-        case 13:
             config.audio_ = false;
             break;
-        case 14:
+        case 13:
             config.video_ = false;
             break;
         default:

--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,7 @@ namespace
     {"tsDemuxLatency", required_argument, nullptr, 0},
     {"jitterBufferLatency", required_argument, nullptr, 0},
     {"srtSourceLatency", required_argument, nullptr, 0},
+    {"h264EncodeBitrate", required_argument, nullptr, 0},
     {"no-audio", no_argument, nullptr, 0},
     {"no-video", no_argument, nullptr, 0},
     {nullptr, no_argument, nullptr, 0}};
@@ -42,6 +43,7 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --tsDemuxLatency INT\n"
                           "  --jitterBufferLatency INT\n"
                           "  --srtSourceLatency INT\n"
+                          "  --h264EncodeBitrate INT (Kb)\n"
                           "  --no-audio\n"
                           "  --no-video\n";
 
@@ -122,9 +124,12 @@ int32_t main(int32_t argc, char** argv)
             config.srtSourceLatency_ = std::strtoul(optarg, nullptr, 10);
             break;
         case 12:
-            config.audio_ = false;
+            config.h264encodeBitrate = std::strtoul(optarg, nullptr, 10);
             break;
         case 13:
+            config.audio_ = false;
+            break;
+        case 14:
             config.video_ = false;
             break;
         default:


### PR DESCRIPTION
This PR tries to solve a out-of-sync [problem](https://github.com/Eyevinn/whip-mpegts/issues/22) for LiveKit WHIP ingress. We noticed that VP8/OPUS streams would have a audio delay if LiveKit is bypassing transcoding. Therefore, we changed  the output of whip-mpegts into H264/OPUS and this seems to solve the problem.

A target bitrate is also added into the configuration so that customer can control the data transfer.

We might want to bypass transcoding in whip-mpegts too if the input SRT stream supports.