### PR TITLE
Feat/support broadcast box

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -20,7 +20,7 @@ struct Config
           tsDemuxLatency_(0),
           jitterBufferLatency_(0),
           srtSourceLatency_(125),
-          h264encodeBitrate(200),
+          h264encodeBitrate(2000),
           audio_(true),
           video_(true)
     {

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -520,8 +520,10 @@ void Pipeline::onOfferCreated(GstPromise* promise)
     auto sendOfferReply = whipClient_.sendOffer(offerString);
     if (sendOfferReply.resource_.empty())
     {
+        Logger::log("Server did not respond with resource");
         return;
     }
+
     whipResource_ = std::move(sendOfferReply.resource_);
     etag_ = std::move((sendOfferReply.etag_));
     Logger::log("Server responded with resource %s, etag %s", whipResource_.c_str(), etag_.c_str());

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ MPEG-TS ingestion client for WHIP (https://github.com/Eyevinn/whip). Ingests an 
 
 Supported platforms are Ubuntu 20.04, 21.10 and OSX.
 
+
 ### Install binary
 
 Homebrew:
@@ -38,6 +39,21 @@ Flags:
 
 - \-t Enable burned in timer
 - \-s Setup SRT socket in listener mode for receiving MPEG-TS and also use SRT when restreaming
+
+### Quick Start
+To play out a testing stream and watch it in browser, we can use [Broadcast Box](https://github.com/Glimesh/broadcast-box).
+
+```
+// Generate a testing stream with GStreamer
+gst-launch-1.0 -v \
+    videotestsrc ! clockoverlay ! video/x-raw, height=360, width=640 ! videoconvert ! x264enc tune=zerolatency ! video/x-h264, profile=constrained-baseline ! mux. \
+    audiotestsrc ! audio/x-raw, format=S16LE, channels=2, rate=44100 ! audioconvert ! voaacenc ! aacparse ! mux. \
+    mpegtsmux name=mux ! queue ! srtsink uri="srt://127.0.0.1:9998?mode=caller" wait-for-connection=false
+
+// Start whip-mpegts with you own Stream Key (e.g., testingstream123) and use Broadcast Box as WHIP endpoint
+./whip-mpegts -a "127.0.0.1" -p 9998 -u "https://b.siobud.com/api/whip" -k "testingstream123"  -s
+```
+Open [Broadcast Box](https://b.siobud.com) in browser and type in the same Stream Key (e.g., testingstream123) and click "Watch Stream".
 
 ### Build Ubuntu 21.10
 

--- a/main.cpp
+++ b/main.cpp
@@ -127,9 +127,12 @@ int32_t main(int32_t argc, char** argv)
             config.srtSourceLatency_ = std::strtoul(optarg, nullptr, 10);
             break;
         case 12:
-            config.audio_ = false;
+            config.h264encodeBitrate = std::strtoul(optarg, nullptr, 10);
             break;
         case 13:
+            config.audio_ = false;
+            break;
+        case 14:
             config.video_ = false;
             break;
         default:


### PR DESCRIPTION
This PR aims to support using Broadcast Box as WHIP endpoint. We added a 'Bearer' into the token header, like OBS studio [did](https://github.com/obsproject/obs-studio/blob/5dda04ad5ee8733cf5b3073d8906f080647a9139/plugins/obs-webrtc/whip-output.cpp#L262) in their latest version.

Additionally, we fixed a tiny error in Config (a wrong index was used for the 'video-only' option). 