### PR TITLE
Feat/bypass transcoding

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -22,7 +22,9 @@ struct Config
           srtSourceLatency_(125),
           h264encodeBitrate(2000),
           audio_(true),
-          video_(true)
+          video_(true),
+          bypass_audio_(false),
+          bypass_video_(false)
     {
     }
 
@@ -74,6 +76,11 @@ struct Config
         result.append("video: ");
         result.append(video_ ? "true" : "false");
         result.append("\n");
+        result.append("bypass audio: ");
+        result.append(bypass_audio_ ? "true" : "false");
+        result.append("\n");
+        result.append("bypass video: ");
+        result.append(bypass_video_ ? "true" : "false");
 
         return result;
     }
@@ -95,4 +102,7 @@ struct Config
 
     bool audio_;
     bool video_;
+
+    bool bypass_audio_;
+    bool bypass_video_;
 };

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -75,6 +75,9 @@ private:
 
         PCM_PARSE,
 
+        OPUS_PARSE,
+        OPUS_DECODE,
+
         AUDIO_CONVERT,
         AUDIO_RESAMPLE,
 
@@ -102,6 +105,7 @@ private:
     void onMpeg2SinkPadAdded(GstPad* newPad);
     void onAacSinkPadAdded(GstPad* newPad);
     void onPcmSinkPadAdded(GstPad* newPad);
+    void onOpusSinkPadAdded(GstPad* newPad);
 
     GstElement* addClockOverlay(GstElement* lastElement);
 };

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Usage: whip-mpegts [OPTION]
   -d, --udpSourceQueueMinTime INT ms
   -r, --restreamAddress STRING
   -o, --restreamPort INT
+  -b, --h264EncodeBitrate INT kb
   -t, --showTimer
   -s, --srtTransport
   --tsDemuxLatency INT
@@ -33,12 +34,16 @@ Usage: whip-mpegts [OPTION]
   --srtSourceLatency INT
   --no-audio
   --no-video
+  --bypass-audio
+  --bypass-video
 ```
 
 Flags:
 
 - \-t Enable burned in timer
 - \-s Setup SRT socket in listener mode for receiving MPEG-TS and also use SRT when restreaming
+- \--bypass-video Skip video transcoding. Only works with H264.
+- \--bypass-audio Skip audio transcoding. Only works with OPUS.
 
 ### Quick Start
 To play out a testing stream and watch it in browser, we can use [Broadcast Box](https://github.com/Glimesh/broadcast-box).

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ cmake -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" .
 make
 ```
 
+Notes:
+For **HTTPS** requests, GLIB (libsoup) requires some environment variables:
+```
+export GLIB_NETWORKING=/opt/homebrew/Cellar/glib-networking/2.78.0
+export GIO_MODULE_DIR=${GLIB_NETWORKING}/lib/gio/modules/
+```
+
 ### Build Docker Container
 
 Build container (uses multi-stage builds):

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,8 @@ namespace
     {"h264EncodeBitrate", required_argument, nullptr, 'b'},
     {"no-audio", no_argument, nullptr, 0},
     {"no-video", no_argument, nullptr, 0},
+    {"bypass-audio", no_argument, nullptr, 0},
+    {"bypass-video", no_argument, nullptr, 0},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:ts";
@@ -45,7 +47,9 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --jitterBufferLatency INT\n"
                           "  --srtSourceLatency INT\n"
                           "  --no-audio\n"
-                          "  --no-video\n";
+                          "  --no-video\n"
+                          "  --bypass-audio\n"
+                          "  --bypass-video\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -134,6 +138,12 @@ int32_t main(int32_t argc, char** argv)
             break;
         case 14:
             config.video_ = false;
+            break;
+        case 15:
+            config.bypass_audio_ = true;
+            break;
+        case 16:
+            config.bypass_video_ = true;
             break;
         default:
             break;


### PR DESCRIPTION
This PR adds video/audio bypass. This works for SRT streams with H264 video and/or OPUS audio.

A quick test was done with commands:
```
./whip-mpegts -a "127.0.0.1" -p 9998 -u "https://b.siobud.com/api/whip" -k "mytestingwhipstream123456789"  -s --bypass-video --bypass-audio

gst-launch-1.0 -v \
    videotestsrc ! clockoverlay ! video/x-raw, height=360, width=640 ! videoconvert ! x264enc tune=zerolatency ! video/x-h264, profile=constrained-baseline ! mux. \
    audiotestsrc ! audioconvert ! opusenc ! mux. \
    mpegtsmux name=mux ! queue ! srtsink uri="srt://127.0.0.1:9998?mode=caller" wait-for-connection=false
```