### PR TITLE
feat: ignore-pcr

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -25,8 +25,15 @@ struct Config
           audio_(true),
           video_(true),
           bypass_audio_(false),
-          bypass_video_(false)
+          bypass_video_(false),
+          ignorePcr_(false)
     {
+        // Load ignorePcr from environment variable if set
+        const char* ignorePcrEnv = std::getenv("IGNORE_PCR");
+        if (ignorePcrEnv != nullptr)
+        {
+            ignorePcr_ = (std::string(ignorePcrEnv) == "true" || std::string(ignorePcrEnv) == "1");
+        }
     }
 
     std::string toString()
@@ -85,6 +92,9 @@ struct Config
         result.append("\n");
         result.append("bypass video: ");
         result.append(bypass_video_ ? "true" : "false");
+        result.append("\n");
+        result.append("ignore PCR: ");
+        result.append(ignorePcr_ ? "true" : "false");
 
         return result;
     }
@@ -110,4 +120,5 @@ struct Config
 
     bool bypass_audio_;
     bool bypass_video_;
+    bool ignorePcr_;
 };

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -270,6 +270,7 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
     }
 
     g_object_set(elements_[ElementLabel::TS_DEMUX], "latency", config.tsDemuxLatency_, nullptr);
+    g_object_set(elements_[ElementLabel::TS_DEMUX], "ignore-pcr", config_.ignorePcr_, nullptr);
     g_signal_connect(elements_[ElementLabel::TS_DEMUX], "pad-added", G_CALLBACK(demuxPadAddedCallback), this);
     g_signal_connect(elements_[ElementLabel::TS_DEMUX], "no-more-pads", G_CALLBACK(demuxNoMorePadsCallback), this);
 

--- a/main.cpp
+++ b/main.cpp
@@ -29,6 +29,7 @@ namespace
     {"no-video", no_argument, nullptr, 0},
     {"bypass-audio", no_argument, nullptr, 0},
     {"bypass-video", no_argument, nullptr, 0},
+    {"ignore-pcr", no_argument, nullptr, 0},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:m:ts";
@@ -51,7 +52,8 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --no-audio\n"
                           "  --no-video\n"
                           "  --bypass-audio\n"
-                          "  --bypass-video\n";
+                          "  --bypass-video\n"
+                          "  --ignore-pcr (can also use IGNORE_PCR env var)\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -163,6 +165,9 @@ int32_t main(int32_t argc, char** argv)
             break;
         case 17:
             config.bypass_video_ = true;
+            break;
+        case 18:
+            config.ignorePcr_ = true;
             break;
         default:
             break;


### PR DESCRIPTION
This adds the ability to set parameter ignore-pcr on tsdemux. Default is false, no change from previous behavior. To set to true, either use enironment var or cli switch --ignore-pcr. 

