### PR TITLE
docs: document output video bitrate control via -b/--h264EncodeBitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage: whip-mpegts [OPTION]
   -d, --udpSourceQueueMinTime INT ms
   -r, --restreamAddress STRING
   -o, --restreamPort INT
-  -b, --h264EncodeBitrate INT kb
+  -b, --h264EncodeBitrate INT kb (video encode bitrate, applies to H264 and VP8)
   -t, --showTimer
   -s, --srtTransport
   -m, --srtMode INT (1=caller, 2=listener, default=2)
@@ -46,6 +46,25 @@ Flags:
 - \-m Set SRT mode: 1 for caller (connect to remote), 2 for listener (wait for connection, default)
 - \--bypass-video Skip video transcoding. Only works with H264.
 - \--bypass-audio Skip audio transcoding. Only works with OPUS.
+
+### Output bitrate
+
+The output video bitrate is directly controllable via `-b, --h264EncodeBitrate INT`, which sets
+the encoder's target bitrate in kilobits per second (kb). It defaults to **2000 kb**. Despite the
+`h264` in the flag name, the value applies to both the H264 (`x264enc`) and VP8 (`vp8enc`)
+encoders — it is passed as the `bitrate` property on `x264enc`, and as `target-bitrate`
+(converted to bits/s) on `vp8enc` when running with `--vp8`.
+
+Because the encoder always re-encodes to this target, the output bitrate is set by `-b` regardless
+of the input stream's bitrate. The input bitrate only influences the output when transcoding is
+active, and even then the encoder re-encodes to the configured target — so observing "lower input
+gives lower output" is incidental, not the intended control knob. Use `-b` to control output
+bitrate.
+
+Note: this bitrate control applies to video only. There is currently no separate output audio
+bitrate flag; audio is re-encoded to Opus (`opusenc`) using the encoder's default settings. When
+video transcoding is skipped with `--bypass-video`, `-b` has no effect since the incoming H264 is
+passed through unchanged.
 
 ### Quick Start
 To play out a testing stream and watch it in browser, we can use [Broadcast Box](https://github.com/Glimesh/broadcast-box).


### PR DESCRIPTION
## Summary
- Implements #35: document output video bitrate control via `-b/--h264EncodeBitrate`

## Changes
- Clarified the `-b, --h264EncodeBitrate` line in the usage block to note it applies to H264 and VP8.
- Added an "Output bitrate" subsection under Flags documenting: the flag sets the encoder target bitrate in kb (default 2000 kb); it applies to both `x264enc` (as `bitrate`) and `vp8enc` (as `target-bitrate`, converted to bits/s); the encoder always re-encodes to this target, so input bitrate is incidental; there is no separate output audio bitrate flag (audio → Opus with defaults); and `-b` has no effect under `--bypass-video`.

## Test plan
Documentation-only change (no build/clang-format applicable). Every claim verified against source:
- Default 2000 kb + field: `Config.h:24` `videoEncodeBitrate(2000)`, `Config.h:120` `uint32_t videoEncodeBitrate`.
- Flag spelling/short opt: `main.cpp:37` `{"h264EncodeBitrate", required_argument, nullptr, 'b'}`.
- Help text: `main.cpp:59`.
- Value assignment: `main.cpp:139-141` `case 'b'`.
- Encoder selection: `Pipeline.cpp:34` (`vp8enc` vs `x264enc`).
- VP8 application: `Pipeline.cpp:79-81` `target-bitrate = videoEncodeBitrate * 1000`.
- H264 application: `Pipeline.cpp:92-96` `bitrate = videoEncodeBitrate`.
- No audio bitrate set on `opusenc`: `Pipeline.cpp:49` (no bitrate property).
- Bypass-video guards encoder config: `Pipeline.cpp:72-74`.

Closes #35

🤖 Automated via WebRTC daily-backlog-pr skill
