### PR TITLE
ci: rerun the Docker build check on every push to a PR

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Test building Docker image on PR
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
The PR build workflow (`.github/workflows/pull-request.yml`) only triggers on
`pull_request: opened`, so pushing a fix commit to an already-open PR never re-verifies the
build — CI just goes stale after the first push.

## Why
This repo's automation (`Eyevinn/agent-team-webrtc`) can't run the CMake/GStreamer toolchain
locally in its sandbox (see [agent-team-webrtc#7](https://github.com/Eyevinn/agent-team-webrtc/issues/7)),
but this repo's own `Dockerfile` already installs that full toolchain and runs `cmake`+`make`
as part of the image build. Making this workflow rerun on every push turns it into the actual
build gate: push → CI builds → read the log if it fails → fix → push again → CI reruns.

## Changes
- `on.pull_request.types`: `[opened]` → `[opened, synchronize]`

## Test plan
Single-line workflow trigger change — verified by reading the GitHub Actions `on.pull_request`
docs for the `synchronize` event type. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)