### PR TITLE
fix: send Bearer prefix on trickle-ICE PATCH Authorization header

### DIFF
--- a/http/WhipClient.cpp
+++ b/http/WhipClient.cpp
@@ -148,7 +148,9 @@ bool WhipClient::updateIce(const std::string& resourceUrl, const std::string& et
     SoupMessageHeaders* requestHeaders = soup_message_get_request_headers(soupMessage);
     if (!authKey_.empty())
     {
-        soup_message_headers_append(requestHeaders, "Authorization", authKey_.c_str());
+        // This is for Broadcast Box compatibility (same as OBS studio)
+        auto bearer_token_header = std::string("Bearer ") + authKey_;
+        soup_message_headers_append(requestHeaders, "Authorization", bearer_token_header.c_str());
     }
     if (!etag.empty())
     {


### PR DESCRIPTION
## Summary
- Implements #53: the trickle-ICE PATCH (`updateIce`) now sends `Authorization: Bearer <key>` instead of the raw key, matching `sendOffer` (POST) and `deleteSession` (DELETE).

## Changes
- `http/WhipClient.cpp` `updateIce`: build the header via `std::string("Bearer ") + authKey_` (same variable name `bearer_token_header` and comment as the other two call sites) before appending it.

## Consistency proof (all three call sites after the change)
POST (`sendOffer`):
```cpp
auto bearer_token_header = std::string("Bearer ") + authKey_;
soup_message_headers_append(requestHeaders, "Authorization", bearer_token_header.c_str());
```
PATCH (`updateIce`, this fix):
```cpp
auto bearer_token_header = std::string("Bearer ") + authKey_;
soup_message_headers_append(requestHeaders, "Authorization", bearer_token_header.c_str());
```
DELETE (`deleteSession`):
```cpp
auto bearer_token_header = std::string("Bearer ") + authKey_;
soup_message_headers_append(requestHeaders, "Authorization", bearer_token_header.c_str());
```
All three now carry an identical `Authorization: Bearer <key>` format when `whipEndpointAuthKey` is set.

## Test plan
- clang-format is not installed in the automation sandbox, so `clang-format --dry-run --Werror` could not be run locally. The 3-line edit was hand-formatted to match the existing `sendOffer`/`deleteSession` blocks verbatim (4-space indent, same identifier/comment), so no style change is introduced.
- CI build proof added as a comment once `gh pr checks --watch` completes.

Closes #53

🤖 Automated via WebRTC daily-backlog-pr skill