### PR TITLE
fix: validate --srtMode and reject unrecognized values

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -192,6 +192,12 @@ int32_t main(int32_t argc, char** argv)
         fprintf(stderr, "Error: --bypass-video and --vp8 cannot be used together\n");
         return 1;
     }
+
+    if (config.srtMode_ != 1 && config.srtMode_ != 2)
+    {
+        fprintf(stderr, "Error: --srtMode must be 1 (caller) or 2 (listener)\n");
+        return 1;
+    }
     Logger::log("Config:\n%s", config.toString().c_str());
 
     mainLoop = g_main_loop_new(nullptr, FALSE);


### PR DESCRIPTION
## Summary
- Implements #54: reject unrecognized `--srtMode` values at startup instead of silently falling back to listener mode.

## Changes
- Added a startup validation in `main.cpp` (after arg parsing, next to the existing `--bypass-video`/`--vp8` check): if `srtMode_` is neither `1` (caller) nor `2` (listener), print `Error: --srtMode must be 1 (caller) or 2 (listener)` to stderr and `return 1`.
- Mirrors the established in-repo validation pattern (same `fprintf(stderr, ...)` + `return 1` style).
- `srtMode_` is parsed via `strtoul`, so non-numeric typos parse to `0` and are now correctly rejected as well.
- Valid `1` and `2` behavior is unchanged.

## Test plan
- PROOF: clang-format was NOT available in the sandbox — the edit was hand-formatted to match the surrounding code exactly; CI is the build gate.
- CI build proof will be added as a comment once checks complete.

Closes #54

🤖 Automated via WebRTC daily-backlog-pr skill