### PR TITLE
feat: add configurable rtph264pay packetization-mode (closes #39)

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -22,6 +22,7 @@ struct Config
           jitterBufferLatency_(0),
           srtSourceLatency_(125),
           videoEncodeBitrate(2000),
+          h264PacketizationMode_(1),
           audio_(true),
           video_(true),
           bypass_audio_(false),
@@ -63,6 +64,9 @@ struct Config
         result.append("\n");
         result.append("videoEncodeBitrate: ");
         result.append(std::to_string(videoEncodeBitrate));
+        result.append("\n");
+        result.append("h264PacketizationMode: ");
+        result.append(std::to_string(h264PacketizationMode_));
         result.append("\n");
         result.append("showTimer: ");
         result.append(showTimer_ ? "true" : "false");
@@ -118,6 +122,7 @@ struct Config
     uint32_t jitterBufferLatency_;
     uint32_t srtSourceLatency_;
     uint32_t videoEncodeBitrate;
+    uint32_t h264PacketizationMode_;
 
     bool audio_;
     bool video_;

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -134,6 +134,17 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
             config.vp8_ ? "VP8" : "H264",
             nullptr));
 
+        // For H264, pin the RTP packetization-mode so it is advertised in the WHIP offer's
+        // fmtp line and matches what the SFU negotiates/expects. VP8 has no packetization-mode.
+        if (!config.vp8_)
+        {
+            gst_caps_set_simple(rtpVideoFilterCaps.get(),
+                "packetization-mode",
+                G_TYPE_STRING,
+                std::to_string(config.h264PacketizationMode_).c_str(),
+                nullptr);
+        }
+
         gst_element_link_filtered(elements_[ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE],
             elements_[ElementLabel::WEBRTC_BIN],
             rtpVideoFilterCaps.get());

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Usage: whip-mpegts [OPTION]
   --bypass-audio
   --bypass-video
   --vp8
+  --h264PacketizationMode INT (0 or 1, default=1)
 ```
 
 Flags:
@@ -78,6 +79,16 @@ Note: this bitrate control applies to video only. There is currently no separate
 bitrate flag; audio is re-encoded to Opus (`opusenc`) using the encoder's default settings. When
 video transcoding is skipped with `--bypass-video`, `-b` has no effect since the incoming H264 is
 passed through unchanged.
+
+### H264 RTP packetization mode
+
+`--h264PacketizationMode INT` controls the H264 RTP packetization-mode that is advertised in the
+WHIP offer's H264 `fmtp` line, so it can be matched to what the receiving SFU negotiates/expects.
+It is signalled via the outgoing RTP capsfilter feeding `webrtcbin`, so it applies to **both** the
+transcode path and the `--bypass-video` passthrough path. Valid values are `0` (single NAL unit /
+non-interleaved without aggregation) and `1` (non-interleaved, allowing STAP-A/FU-A). The default
+is `1`, which preserves the previous behaviour. The flag has no effect when encoding VP8
+(`--vp8`), which has no packetization-mode.
 
 ### How it works
 

--- a/main.cpp
+++ b/main.cpp
@@ -22,6 +22,7 @@ enum : int
     OPT_BYPASS_VIDEO,
     OPT_IGNORE_PCR,
     OPT_VP8,
+    OPT_H264_PACKETIZATION_MODE,
 };
 
 ::option longOptions[] = {{"udpSourceAddress", required_argument, nullptr, 'a'},
@@ -44,6 +45,7 @@ enum : int
     {"bypass-video", no_argument, nullptr, OPT_BYPASS_VIDEO},
     {"ignore-pcr", no_argument, nullptr, OPT_IGNORE_PCR},
     {"vp8", no_argument, nullptr, OPT_VP8},
+    {"h264PacketizationMode", required_argument, nullptr, OPT_H264_PACKETIZATION_MODE},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:m:ts";
@@ -68,7 +70,8 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --bypass-audio\n"
                           "  --bypass-video\n"
                           "  --ignore-pcr (can also use IGNORE_PCR env var)\n"
-                          "  --vp8 (encode video as VP8 instead of H264)\n";
+                          "  --vp8 (encode video as VP8 instead of H264)\n"
+                          "  --h264PacketizationMode INT (H264 RTP packetization-mode, 0 or 1, default=1)\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -174,6 +177,9 @@ int32_t main(int32_t argc, char** argv)
             break;
         case OPT_VP8:
             config.vp8_ = true;
+            break;
+        case OPT_H264_PACKETIZATION_MODE:
+            config.h264PacketizationMode_ = std::strtoul(optarg, nullptr, 10);
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
Expose the H264 RTP packetization-mode advertised in the WHIP offer's fmtp line as a CLI option, so it can be matched to what the receiving SFU negotiates.

## Changes
- `Config.h`: new `h264PacketizationMode_` field (default `1`) + toString entry.
- `main.cpp`: new `--h264PacketizationMode INT` long-option plumbed through getopt_long and usage string.
- `Pipeline.cpp`: set `packetization-mode` on the outgoing RTP video capsfilter (`RTP_VIDEO_FILTER` caps) for H264 so it is signalled in the SDP offer's fmtp. Since this filter feeds `webrtcbin` for all video, it applies to both the transcode and `--bypass-video` paths. No effect for VP8 (no packetization-mode).
- `README.md`: documented the flag.

## Test plan
- [ ] clang-format PROOF: `clang-format` is not installed in this environment (`clang-format --dry-run --Werror` unavailable). Edits were hand-formatted to match the surrounding code and the repo `.clang-format` (4-space indent, `BinPackArguments: false`, 120 col). CI's Docker build is the build gate.
- [ ] Verify the SDP offer's H264 fmtp advertises the requested `packetization-mode` against a live WHIP endpoint.

Closes #39

🤖 Automated via WebRTC daily-backlog-pr skill