### PR TITLE
feat: constrain x264enc to a selectable H264 profile (closes #40)

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -23,6 +23,7 @@ struct Config
           srtSourceLatency_(125),
           videoEncodeBitrate(2000),
           h264PacketizationMode_(1),
+          h264Profile_("constrained-baseline"),
           audio_(true),
           video_(true),
           bypass_audio_(false),
@@ -67,6 +68,9 @@ struct Config
         result.append("\n");
         result.append("h264PacketizationMode: ");
         result.append(std::to_string(h264PacketizationMode_));
+        result.append("\n");
+        result.append("h264Profile: ");
+        result.append(h264Profile_);
         result.append("\n");
         result.append("showTimer: ");
         result.append(showTimer_ ? "true" : "false");
@@ -123,6 +127,7 @@ struct Config
     uint32_t srtSourceLatency_;
     uint32_t videoEncodeBitrate;
     uint32_t h264PacketizationMode_;
+    std::string h264Profile_;
 
     bool audio_;
     bool video_;

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -32,6 +32,7 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
     makeElement(ElementLabel::MPEG2_DECODE, "avdec_mpeg2video");
 
     makeElement(ElementLabel::RTP_VIDEO_ENCODE, config.vp8_ ? "vp8enc" : "x264enc");
+    makeElement(ElementLabel::RTP_VIDEO_ENCODE_CAPS, "capsfilter");
     makeElement(ElementLabel::RTP_VIDEO_PAYLOAD, config.vp8_ ? "rtpvp8pay" : "rtph264pay");
     makeElement(ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE, "queue");
     makeElement(ElementLabel::RTP_VIDEO_FILTER, "capsfilter");
@@ -99,6 +100,13 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
             "speed-preset",
             1, // ultrafast
             nullptr);
+
+        // Pin the encoded H264 profile via caps on the encoder src, mirroring the
+        // "x264enc ! video/x-h264, profile=..." pattern in the README gst-launch examples.
+        // Only affects the transcode path; the --bypass-video path never touches x264enc.
+        utils::ScopedGstObject encodeCaps(
+            gst_caps_new_simple("video/x-h264", "profile", G_TYPE_STRING, config.h264Profile_.c_str(), nullptr));
+        g_object_set(elements_[ElementLabel::RTP_VIDEO_ENCODE_CAPS], "caps", encodeCaps.get(), nullptr);
     }
 
     if (config.audio_)
@@ -451,6 +459,7 @@ void Pipeline::onH264SinkPadAdded(GstPad* newPad)
         if (!gst_element_link_many(lastElement,
                 elements_[ElementLabel::VIDEO_CONVERT],
                 elements_[ElementLabel::RTP_VIDEO_ENCODE],
+                elements_[ElementLabel::RTP_VIDEO_ENCODE_CAPS],
                 elements_[ElementLabel::RTP_VIDEO_PAYLOAD],
                 elements_[ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE],
                 nullptr))
@@ -489,6 +498,7 @@ void Pipeline::onH265SinkPadAdded(GstPad* newPad)
     if (!gst_element_link_many(lastElement,
             elements_[ElementLabel::VIDEO_CONVERT],
             elements_[ElementLabel::RTP_VIDEO_ENCODE],
+            elements_[ElementLabel::RTP_VIDEO_ENCODE_CAPS],
             elements_[ElementLabel::RTP_VIDEO_PAYLOAD],
             elements_[ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE],
             nullptr))
@@ -518,6 +528,7 @@ void Pipeline::onMpeg2SinkPadAdded(GstPad* newPad)
             elements_[ElementLabel::MPEG2_DECODE],
             elements_[ElementLabel::VIDEO_CONVERT],
             elements_[ElementLabel::RTP_VIDEO_ENCODE],
+            elements_[ElementLabel::RTP_VIDEO_ENCODE_CAPS],
             elements_[ElementLabel::RTP_VIDEO_PAYLOAD],
             elements_[ElementLabel::RTP_VIDEO_PAYLOAD_QUEUE],
             nullptr))

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -79,6 +79,7 @@ private:
         MPEG2_DECODE,
 
         RTP_VIDEO_ENCODE,
+        RTP_VIDEO_ENCODE_CAPS,
         RTP_VIDEO_PAYLOAD,
         RTP_VIDEO_PAYLOAD_QUEUE,
         RTP_VIDEO_FILTER,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Usage: whip-mpegts [OPTION]
   --bypass-video
   --vp8
   --h264PacketizationMode INT (0 or 1, default=1)
+  --h264Profile STRING (default=constrained-baseline)
 ```
 
 Flags:
@@ -89,6 +90,17 @@ transcode path and the `--bypass-video` passthrough path. Valid values are `0` (
 non-interleaved without aggregation) and `1` (non-interleaved, allowing STAP-A/FU-A). The default
 is `1`, which preserves the previous behaviour. The flag has no effect when encoding VP8
 (`--vp8`), which has no packetization-mode.
+
+### H264 encoder profile
+
+`--h264Profile STRING` pins the H264 profile of the transcoded output so it matches what the
+receiving SFU is configured for. It is enforced via a caps constraint on the `x264enc` src
+(`video/x-h264, profile=<value>`), mirroring the `x264enc ! video/x-h264, profile=...` pattern in
+the gst-launch examples below. The default is `constrained-baseline`, and existing behaviour is
+unchanged when the flag is omitted. Typical values are `constrained-baseline`, `baseline`, `main`,
+and `high`. This only affects the **transcode** path: with `--bypass-video` the incoming H264 is
+forwarded unchanged and its profile is the upstream encoder's responsibility, and with `--vp8` the
+flag has no effect (VP8 has no H264 profile).
 
 ### How it works
 

--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,7 @@ enum : int
     OPT_IGNORE_PCR,
     OPT_VP8,
     OPT_H264_PACKETIZATION_MODE,
+    OPT_H264_PROFILE,
 };
 
 ::option longOptions[] = {{"udpSourceAddress", required_argument, nullptr, 'a'},
@@ -46,6 +47,7 @@ enum : int
     {"ignore-pcr", no_argument, nullptr, OPT_IGNORE_PCR},
     {"vp8", no_argument, nullptr, OPT_VP8},
     {"h264PacketizationMode", required_argument, nullptr, OPT_H264_PACKETIZATION_MODE},
+    {"h264Profile", required_argument, nullptr, OPT_H264_PROFILE},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:m:ts";
@@ -71,7 +73,8 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --bypass-video\n"
                           "  --ignore-pcr (can also use IGNORE_PCR env var)\n"
                           "  --vp8 (encode video as VP8 instead of H264)\n"
-                          "  --h264PacketizationMode INT (H264 RTP packetization-mode, 0 or 1, default=1)\n";
+                          "  --h264PacketizationMode INT (H264 RTP packetization-mode, 0 or 1, default=1)\n"
+                          "  --h264Profile STRING (H264 encoder profile, default=constrained-baseline)\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -180,6 +183,9 @@ int32_t main(int32_t argc, char** argv)
             break;
         case OPT_H264_PACKETIZATION_MODE:
             config.h264PacketizationMode_ = std::strtoul(optarg, nullptr, 10);
+            break;
+        case OPT_H264_PROFILE:
+            config.h264Profile_ = optarg;
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
Pin the transcoded H264 profile so encoded output matches what the SFU is configured for, defaulting to constrained-baseline.

## Changes
- `Config.h`: new `h264Profile_` field (default `constrained-baseline`) + toString entry.
- `main.cpp`: new `--h264Profile STRING` long-option.
- `Pipeline.h`: new `RTP_VIDEO_ENCODE_CAPS` element label.
- `Pipeline.cpp`: insert a capsfilter after `x264enc` constraining `video/x-h264, profile=<value>` (mirroring the README `x264enc ! video/x-h264, profile=...` pattern) and link it into the three transcode chains (H264/H265/MPEG2). The capsfilter is passthrough for VP8 and is never in the `--bypass-video` path, so only the transcode path is affected.
- `README.md`: documented the flag.

## Test plan
- [ ] clang-format PROOF: `clang-format` not installed here; edits hand-formatted to match the repo `.clang-format`. CI Docker build is the gate.
- [ ] Verify encoded stream reports the requested profile via SDP profile-level-id / h264parse caps.

Closes #40

🤖 Automated via WebRTC daily-backlog-pr skill