### PR TITLE
feat: enforce frequent keyframe interval on x264enc (closes #41)

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -24,6 +24,7 @@ struct Config
           videoEncodeBitrate(2000),
           h264PacketizationMode_(1),
           h264Profile_("constrained-baseline"),
+          h264KeyframeInterval_(60),
           audio_(true),
           video_(true),
           bypass_audio_(false),
@@ -72,6 +73,9 @@ struct Config
         result.append("h264Profile: ");
         result.append(h264Profile_);
         result.append("\n");
+        result.append("h264KeyframeInterval: ");
+        result.append(std::to_string(h264KeyframeInterval_));
+        result.append(" frames\n");
         result.append("showTimer: ");
         result.append(showTimer_ ? "true" : "false");
         result.append("\n");
@@ -128,6 +132,7 @@ struct Config
     uint32_t videoEncodeBitrate;
     uint32_t h264PacketizationMode_;
     std::string h264Profile_;
+    uint32_t h264KeyframeInterval_;
 
     bool audio_;
     bool video_;

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -99,6 +99,8 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
             1, // zerolatency
             "speed-preset",
             1, // ultrafast
+            "key-int-max",
+            config.h264KeyframeInterval_, // frequent IDR frames for WebRTC/SFU late-join recovery
             nullptr);
 
         // Pin the encoded H264 profile via caps on the encoder src, mirroring the

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Usage: whip-mpegts [OPTION]
   --vp8
   --h264PacketizationMode INT (0 or 1, default=1)
   --h264Profile STRING (default=constrained-baseline)
+  --h264KeyframeInterval INT (frames, default=60)
 ```
 
 Flags:
@@ -101,6 +102,18 @@ unchanged when the flag is omitted. Typical values are `constrained-baseline`, `
 and `high`. This only affects the **transcode** path: with `--bypass-video` the incoming H264 is
 forwarded unchanged and its profile is the upstream encoder's responsibility, and with `--vp8` the
 flag has no effect (VP8 has no H264 profile).
+
+### Keyframe interval
+
+For WebRTC/SFU delivery, keyframes (IDR frames) must appear frequently so late-joining
+subscribers can start decoding quickly. On the transcode path the H264 encoder (`x264enc`) is
+configured with `key-int-max` set from `--h264KeyframeInterval INT` (in **frames**), defaulting to
+`60` — roughly one keyframe every two seconds at 30 fps. Lower the value for faster recovery at the
+cost of bitrate efficiency.
+
+This only affects the **transcode** path. With `--bypass-video` the keyframe cadence is entirely
+the upstream encoder's responsibility, since the incoming H264 is forwarded unchanged. The flag
+also has no effect when encoding VP8 (`--vp8`).
 
 ### How it works
 

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,7 @@ enum : int
     OPT_VP8,
     OPT_H264_PACKETIZATION_MODE,
     OPT_H264_PROFILE,
+    OPT_H264_KEYFRAME_INTERVAL,
 };
 
 ::option longOptions[] = {{"udpSourceAddress", required_argument, nullptr, 'a'},
@@ -48,6 +49,7 @@ enum : int
     {"vp8", no_argument, nullptr, OPT_VP8},
     {"h264PacketizationMode", required_argument, nullptr, OPT_H264_PACKETIZATION_MODE},
     {"h264Profile", required_argument, nullptr, OPT_H264_PROFILE},
+    {"h264KeyframeInterval", required_argument, nullptr, OPT_H264_KEYFRAME_INTERVAL},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:m:ts";
@@ -74,7 +76,8 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --ignore-pcr (can also use IGNORE_PCR env var)\n"
                           "  --vp8 (encode video as VP8 instead of H264)\n"
                           "  --h264PacketizationMode INT (H264 RTP packetization-mode, 0 or 1, default=1)\n"
-                          "  --h264Profile STRING (H264 encoder profile, default=constrained-baseline)\n";
+                          "  --h264Profile STRING (H264 encoder profile, default=constrained-baseline)\n"
+                          "  --h264KeyframeInterval INT (x264enc key-int-max in frames, default=60)\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -186,6 +189,9 @@ int32_t main(int32_t argc, char** argv)
             break;
         case OPT_H264_PROFILE:
             config.h264Profile_ = optarg;
+            break;
+        case OPT_H264_KEYFRAME_INTERVAL:
+            config.h264KeyframeInterval_ = std::strtoul(optarg, nullptr, 10);
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
Set an explicit `key-int-max` on `x264enc` so keyframes appear frequently for WebRTC/SFU late-join recovery.

## Changes
- `Config.h`: new `h264KeyframeInterval_` field (default `60` frames, ~2s at 30 fps) + toString entry.
- `main.cpp`: new `--h264KeyframeInterval INT` long-option.
- `Pipeline.cpp`: set `key-int-max` on `x264enc` from the config value in the transcode encoder-config block.
- `README.md`: documented the behaviour and that `--bypass-video` cadence remains the upstream encoder's job.

## Test plan
- [ ] clang-format PROOF: `clang-format` not installed here; edits hand-formatted to match the repo `.clang-format`. CI Docker build is the gate.
- [ ] Verify IDR frames appear at the configured interval via h264parse / GST logs.

Closes #41

🤖 Automated via WebRTC daily-backlog-pr skill