### PR TITLE
feat: wire GCC bandwidth estimator into sender pipeline (closes #44)

### DIFF
--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -157,6 +157,29 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
         this);
     g_signal_connect(elements_[ElementLabel::WEBRTC_BIN], "on-ice-candidate", G_CALLBACK(onIceCandidateCallback), this);
 
+    // Wire the GCC bandwidth estimator into the send-side webrtcbin (issue #44). webrtcbin asks
+    // the application for an aux sender per send transport via "request-aux-sender"; we hand back
+    // an rtpgccbwe element that consumes incoming TWCC feedback and produces an estimated
+    // available bitrate. The estimate is only logged for now; acting on it is issue #45. The
+    // rtpgccbwe element lives in gst-plugins-rs and may be absent from the image, so guard on its
+    // availability and degrade gracefully (unchanged behaviour) when it is missing.
+    if (config.video_)
+    {
+        utils::ScopedGLibObject<GstElementFactory*> gccFactory(gst_element_factory_find("rtpgccbwe"));
+        if (gccFactory.get() != nullptr)
+        {
+            Logger::log("rtpgccbwe available - connecting GCC bandwidth estimator to webrtcbin");
+            g_signal_connect(elements_[ElementLabel::WEBRTC_BIN],
+                "request-aux-sender",
+                G_CALLBACK(requestAuxSenderCallback),
+                this);
+        }
+        else
+        {
+            Logger::log("rtpgccbwe element not found - GCC bandwidth estimation disabled");
+        }
+    }
+
     makeElement(ElementLabel::UDP_QUEUE, "queue");
     makeElement(ElementLabel::TS_DEMUX, "tsdemux");
     if (!gst_element_link_many(elements_[ElementLabel::UDP_QUEUE], elements_[ElementLabel::TS_DEMUX], nullptr))
@@ -853,4 +876,71 @@ gboolean Pipeline::signalHandlerCallback(gpointer userData)
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-sighup");
     Logger::log("Pipeline .dot file dumped: pipeline-sighup.dot");
     return G_SOURCE_CONTINUE; // Keep the signal handler active
+}
+
+GstElement* Pipeline::requestAuxSenderCallback(GstElement* /*webRtcBin*/, guint sessionId, gpointer userData)
+{
+    auto pipelineImpl = reinterpret_cast<Pipeline*>(userData);
+    return pipelineImpl->onRequestAuxSender(sessionId);
+}
+
+GstElement* Pipeline::onRequestAuxSender(guint sessionId)
+{
+    // Create the GCC estimator. Availability was already checked before connecting the signal,
+    // but guard again in case the element cannot be instantiated for some reason.
+    GstElement* gccBwe = gst_element_factory_make("rtpgccbwe", nullptr);
+    if (gccBwe == nullptr)
+    {
+        Logger::log("Unable to make rtpgccbwe element for session %u - no bandwidth estimation", sessionId);
+        return nullptr;
+    }
+
+    // Seed the estimator from the configured video bitrate. rtpgccbwe bitrate properties are in
+    // bits per second, while config.videoEncodeBitrate is in kb/s (mirroring the VP8
+    // target-bitrate conversion above): min = 10% of target, start = target, max = target.
+    const guint targetBps = config_.videoEncodeBitrate * 1000;
+    const guint minBps = targetBps / 10;
+    g_object_set(gccBwe,
+        "min-bitrate",
+        minBps,
+        "estimated-bitrate",
+        targetBps,
+        "max-bitrate",
+        targetBps,
+        nullptr);
+
+    Logger::log("Created rtpgccbwe for session %u (min=%u start=%u max=%u bps)",
+        sessionId,
+        minBps,
+        targetBps,
+        targetBps);
+
+    lastEstimateLog_ = std::chrono::steady_clock::time_point{};
+    g_signal_connect(gccBwe, "notify::estimated-bitrate", G_CALLBACK(estimatedBitrateNotifyCallback), this);
+
+    return gccBwe;
+}
+
+void Pipeline::estimatedBitrateNotifyCallback(GstObject* gccBwe, GParamSpec* /*pspec*/, gpointer userData)
+{
+    auto pipelineImpl = reinterpret_cast<Pipeline*>(userData);
+    pipelineImpl->onEstimatedBitrate(gccBwe);
+}
+
+void Pipeline::onEstimatedBitrate(GstObject* gccBwe)
+{
+    // Fires on the estimator's own streaming thread. Throttle the log to at most once per second
+    // so the estimation loop is observable without flooding the log. Do NOT act on the estimate
+    // yet - re-targeting the encoder is issue #45.
+    const auto now = std::chrono::steady_clock::now();
+    if (lastEstimateLog_ != std::chrono::steady_clock::time_point{} &&
+        (now - lastEstimateLog_) < std::chrono::seconds(1))
+    {
+        return;
+    }
+    lastEstimateLog_ = now;
+
+    guint estimatedBps = 0;
+    g_object_get(gccBwe, "estimated-bitrate", &estimatedBps, nullptr);
+    Logger::log("GCC estimated available bitrate: %u bps (%u kb/s)", estimatedBps, estimatedBps / 1000);
 }

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -39,6 +39,17 @@ public:
     static void onIceCandidateCallback(GstElement* /*webrtc*/, guint mLineIndex, gchar* candidate, gpointer userData);
     static gboolean signalHandlerCallback(gpointer userData);
 
+    // GCC bandwidth estimator (issue #44): webrtcbin requests an aux sender for each send
+    // transport; we return an rtpgccbwe element seeded from the configured video bitrate and
+    // observe its estimate. The estimate is only logged for now (issue #45 will act on it).
+    static GstElement* requestAuxSenderCallback(GstElement* webRtcBin,
+        guint sessionId,
+        gpointer userData);
+    static void estimatedBitrateNotifyCallback(GstObject* gccBwe, GParamSpec* pspec, gpointer userData);
+
+    GstElement* onRequestAuxSender(guint sessionId);
+    void onEstimatedBitrate(GstObject* gccBwe);
+
 private:
 private:
     enum class ElementLabel
@@ -100,6 +111,10 @@ private:
 
     std::string whipResource_;
     std::string etag_;
+
+    // Throttle for the GCC estimated-bitrate log (issue #44). The notify fires on the
+    // estimator's streaming thread, so this is only touched from that handler.
+    std::chrono::steady_clock::time_point lastEstimateLog_;
 
     void makeElement(const ElementLabel elementLabel, const char* element);
     void onH264SinkPadAdded(GstPad* newPad);

--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ gst-launch-1.0 -v \
 Here `key-int-max=30` and `profile=constrained-baseline` are chosen on the
 source encoder, since on the bypass path this tool forwards them unchanged.
 
+## Bandwidth estimation (experimental)
+
+When the send path negotiates transport-wide congestion control (TWCC), `whip-mpegts` can attach a
+Google Congestion Control (GCC) bandwidth estimator to the outgoing `webrtcbin` for the **video**
+track. The estimator (`rtpgccbwe`) consumes the TWCC feedback returned by the receiver and produces
+a continuously updated estimate of the available uplink bitrate. The estimator is seeded from the
+configured video bitrate (`-b, --h264EncodeBitrate`): minimum = 10% of the target, start = the
+target, maximum = the target (all in bits per second).
+
+At this stage the estimate is only **logged** (throttled to about once per second) so the loop can
+be observed; it does **not** yet change the encoder bitrate — reacting to the estimate is tracked
+separately. The estimator is attached only when the `rtpgccbwe` element is present in the GStreamer
+installation; if it is missing, bandwidth estimation is skipped and behaviour is unchanged. It
+applies to the video transceiver only; the Opus audio track is out of scope.
+
 ## Debugging
 
 ### Pipeline State Debugging


### PR DESCRIPTION
## Summary
Attach a Google Congestion Control (`rtpgccbwe`) bandwidth estimator to the send-side `webrtcbin` for the video transceiver, following the #43 spike (`docs/spikes/twcc-gcc-bandwidth-estimation.md`). The estimate is only logged for now; acting on it is issue #45.

## Changes
- `Pipeline.h`: `request-aux-sender` / `notify::estimated-bitrate` static callbacks + instance handlers, and a throttle timestamp member.
- `Pipeline.cpp`:
  - Connect `request-aux-sender` on `webrtcbin` (video only), guarded by `gst_element_factory_find("rtpgccbwe")` so the pipeline degrades gracefully (unchanged behaviour) when the plugin is absent.
  - On request, create `rtpgccbwe` seeded from `config.videoEncodeBitrate` (bps): `min` = 10% of target, `estimated` (start) = target, `max` = target.
  - Log the estimated bitrate throttled to ~1 Hz on `notify::estimated-bitrate`; do not change the encoder.
- `README.md`: documented the experimental estimator.

## Test plan
- [ ] clang-format PROOF: `clang-format` not installed here; edits hand-formatted to match the repo `.clang-format`. CI Docker build is the gate.
- [ ] **Compile-verified via CI only.** Runtime acceptance (observing a changing estimate under induced loss against a live WHIP endpoint) CANNOT be verified in the automation sandbox — there is no runtime. **A human must run this against a live WHIP endpoint with induced loss before the behaviour is trusted.** Note also that per the spike, TWCC-on-the-wire is unconfirmed and `rtpgccbwe` is not in the current Docker image (gst-plugins-rs) — the code guards on the element's presence and no-ops if absent, so CI will build but the estimator will only activate once the plugin is packaged in and TWCC is confirmed negotiated.

Closes #44

🤖 Automated via WebRTC daily-backlog-pr skill