### PR TITLE
feat: opt-in sender congestion control (--congestion-control) applying GCC estimate to encoder

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -30,7 +30,8 @@ struct Config
           bypass_audio_(false),
           bypass_video_(false),
           ignorePcr_(false),
-          vp8_(false)
+          vp8_(false),
+          congestionControl_(false)
     {
         // Load ignorePcr from environment variable if set
         const char* ignorePcrEnv = std::getenv("IGNORE_PCR");
@@ -111,6 +112,9 @@ struct Config
         result.append("\n");
         result.append("vp8: ");
         result.append(vp8_ ? "true" : "false");
+        result.append("\n");
+        result.append("congestionControl: ");
+        result.append(congestionControl_ ? "true" : "false");
 
         return result;
     }
@@ -141,4 +145,5 @@ struct Config
     bool bypass_video_;
     bool ignorePcr_;
     bool vp8_;
+    bool congestionControl_;
 };

--- a/Pipeline.cpp
+++ b/Pipeline.cpp
@@ -181,15 +181,23 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
     // Wire the GCC bandwidth estimator into the send-side webrtcbin (issue #44). webrtcbin asks
     // the application for an aux sender per send transport via "request-aux-sender"; we hand back
     // an rtpgccbwe element that consumes incoming TWCC feedback and produces an estimated
-    // available bitrate. The estimate is only logged for now; acting on it is issue #45. The
-    // rtpgccbwe element lives in gst-plugins-rs and may be absent from the image, so guard on its
-    // availability and degrade gracefully (unchanged behaviour) when it is missing.
-    if (config.video_)
+    // available bitrate. When --congestion-control is set the estimate is applied to the video
+    // encoder bitrate (issue #45); otherwise it is only logged. The rtpgccbwe element lives in
+    // gst-plugins-rs and may be absent from the image, so guard on its availability and degrade
+    // gracefully (unchanged behaviour) when it is missing.
+    //
+    // Gating (issue #46): the whole estimator is wired up only when the opt-in flag is set. With
+    // the flag off, behaviour is byte-for-byte the pre-existing static config.videoEncodeBitrate
+    // path (no estimator, no dynamic updates). --bypass-video has no encoder on its passthrough
+    // path, so dynamic bitrate has nothing to act on; the flag is a no-op there and we skip the
+    // wiring entirely rather than attaching an estimator that could never re-target anything.
+    if (config.congestionControl_ && config.video_ && !config.bypass_video_)
     {
         utils::ScopedGLibObject<GstElementFactory*> gccFactory(gst_element_factory_find("rtpgccbwe"));
         if (gccFactory.get() != nullptr)
         {
-            Logger::log("rtpgccbwe available - connecting GCC bandwidth estimator to webrtcbin");
+            Logger::log(
+                "rtpgccbwe available - connecting GCC bandwidth estimator to webrtcbin (congestion control on)");
             g_signal_connect(elements_[ElementLabel::WEBRTC_BIN],
                 "request-aux-sender",
                 G_CALLBACK(requestAuxSenderCallback),
@@ -197,8 +205,12 @@ Pipeline::Pipeline(http::WhipClient& whipClient, const Config& config) : whipCli
         }
         else
         {
-            Logger::log("rtpgccbwe element not found - GCC bandwidth estimation disabled");
+            Logger::log("rtpgccbwe element not found - sender congestion control disabled");
         }
+    }
+    else if (config.congestionControl_ && config.bypass_video_)
+    {
+        Logger::log("--congestion-control has no effect with --bypass-video (no encoder to re-target) - ignoring");
     }
 
     makeElement(ElementLabel::UDP_QUEUE, "queue");
@@ -924,20 +936,21 @@ GstElement* Pipeline::onRequestAuxSender(guint sessionId)
     // target-bitrate conversion above): min = 10% of target, start = target, max = target.
     const guint targetBps = config_.videoEncodeBitrate * 1000;
     const guint minBps = targetBps / 10;
-    g_object_set(gccBwe,
-        "min-bitrate",
-        minBps,
-        "estimated-bitrate",
-        targetBps,
-        "max-bitrate",
-        targetBps,
-        nullptr);
+    g_object_set(gccBwe, "min-bitrate", minBps, "estimated-bitrate", targetBps, "max-bitrate", targetBps, nullptr);
 
     Logger::log("Created rtpgccbwe for session %u (min=%u start=%u max=%u bps)",
         sessionId,
         minBps,
         targetBps,
         targetBps);
+
+    // Remember the clamp bounds (bits per second) so estimates applied to the encoder never fall
+    // below 10% of the configured target or exceed it (issue #45). Seed lastAppliedBitrate_ with
+    // the configured target because that is what the encoder was statically configured with.
+    minEncoderBitrateBps_ = minBps;
+    maxEncoderBitrateBps_ = targetBps;
+    lastAppliedBitrateBps_ = targetBps;
+    lastBitrateApply_ = std::chrono::steady_clock::time_point{};
 
     lastEstimateLog_ = std::chrono::steady_clock::time_point{};
     g_signal_connect(gccBwe, "notify::estimated-bitrate", G_CALLBACK(estimatedBitrateNotifyCallback), this);
@@ -953,18 +966,60 @@ void Pipeline::estimatedBitrateNotifyCallback(GstObject* gccBwe, GParamSpec* /*p
 
 void Pipeline::onEstimatedBitrate(GstObject* gccBwe)
 {
-    // Fires on the estimator's own streaming thread. Throttle the log to at most once per second
-    // so the estimation loop is observable without flooding the log. Do NOT act on the estimate
-    // yet - re-targeting the encoder is issue #45.
+    // Fires on the estimator's own streaming thread. Read the current estimate first.
+    guint estimatedBps = 0;
+    g_object_get(gccBwe, "estimated-bitrate", &estimatedBps, nullptr);
+
     const auto now = std::chrono::steady_clock::now();
-    if (lastEstimateLog_ != std::chrono::steady_clock::time_point{} &&
-        (now - lastEstimateLog_) < std::chrono::seconds(1))
+
+    // Throttle the log to at most once per second so the estimation loop is observable without
+    // flooding the log.
+    if (lastEstimateLog_ == std::chrono::steady_clock::time_point{} ||
+        (now - lastEstimateLog_) >= std::chrono::seconds(1))
+    {
+        lastEstimateLog_ = now;
+        Logger::log("GCC estimated available bitrate: %u bps (%u kb/s)", estimatedBps, estimatedBps / 1000);
+    }
+
+    // The estimator is only wired up when congestion control is enabled (issue #46 gates the
+    // signal connection in the constructor), so reaching here already implies the flag is on and
+    // an encoder exists (never the --bypass-video path). Apply the estimate to the encoder.
+    //
+    // Clamp to [min, max] (bits per second) so we never starve or overshoot the configured
+    // target, then rate-limit to at most once per second and skip sub-2% changes so we do not
+    // thrash the encoder with churn from the continuously updating estimate (issue #45).
+    guint targetBps = std::max(minEncoderBitrateBps_, std::min(estimatedBps, maxEncoderBitrateBps_));
+
+    if (lastBitrateApply_ != std::chrono::steady_clock::time_point{} &&
+        (now - lastBitrateApply_) < std::chrono::seconds(1))
     {
         return;
     }
-    lastEstimateLog_ = now;
 
-    guint estimatedBps = 0;
-    g_object_get(gccBwe, "estimated-bitrate", &estimatedBps, nullptr);
-    Logger::log("GCC estimated available bitrate: %u bps (%u kb/s)", estimatedBps, estimatedBps / 1000);
+    const guint delta =
+        targetBps > lastAppliedBitrateBps_ ? targetBps - lastAppliedBitrateBps_ : lastAppliedBitrateBps_ - targetBps;
+    if (lastAppliedBitrateBps_ != 0 && delta < (lastAppliedBitrateBps_ / 50))
+    {
+        return;
+    }
+
+    // Setting the encoder bitrate directly from this streaming-thread handler is safe: GObject
+    // property setters take the instance lock, and both x264enc "bitrate" and vp8enc
+    // "target-bitrate" are GST_PARAM_MUTABLE_PLAYING, i.e. defined to be changeable at runtime
+    // while the element is PLAYING. So no marshalling to the main loop is required.
+    //
+    // Respect the unit difference already present in Pipeline.cpp: x264enc "bitrate" is in kb/s,
+    // vp8enc "target-bitrate" is in bits per second.
+    if (config_.vp8_)
+    {
+        g_object_set(elements_[ElementLabel::RTP_VIDEO_ENCODE], "target-bitrate", targetBps, nullptr);
+    }
+    else
+    {
+        g_object_set(elements_[ElementLabel::RTP_VIDEO_ENCODE], "bitrate", targetBps / 1000, nullptr);
+    }
+
+    lastAppliedBitrateBps_ = targetBps;
+    lastBitrateApply_ = now;
+    Logger::log("Applied congestion-controlled encoder bitrate: %u bps (%u kb/s)", targetBps, targetBps / 1000);
 }

--- a/Pipeline.h
+++ b/Pipeline.h
@@ -41,10 +41,9 @@ public:
 
     // GCC bandwidth estimator (issue #44): webrtcbin requests an aux sender for each send
     // transport; we return an rtpgccbwe element seeded from the configured video bitrate and
-    // observe its estimate. The estimate is only logged for now (issue #45 will act on it).
-    static GstElement* requestAuxSenderCallback(GstElement* webRtcBin,
-        guint sessionId,
-        gpointer userData);
+    // observe its estimate. When --congestion-control is enabled (issue #45/#46) the estimate is
+    // applied to the video encoder bitrate; otherwise it is only logged.
+    static GstElement* requestAuxSenderCallback(GstElement* webRtcBin, guint sessionId, gpointer userData);
     static void estimatedBitrateNotifyCallback(GstObject* gccBwe, GParamSpec* pspec, gpointer userData);
 
     GstElement* onRequestAuxSender(guint sessionId);
@@ -116,6 +115,17 @@ private:
     // Throttle for the GCC estimated-bitrate log (issue #44). The notify fires on the
     // estimator's streaming thread, so this is only touched from that handler.
     std::chrono::steady_clock::time_point lastEstimateLog_;
+
+    // Dynamic-bitrate application state (issues #45/#46). Only used when
+    // config_.congestionControl_ is set. Bounds are in bits per second and derived from the
+    // configured target the same way the estimator seed is (min = 10% of target, max = target).
+    // lastAppliedBitrate_ and lastBitrateApply_ rate-limit encoder re-targeting so we do not
+    // thrash the encoder. All of these are touched only from the estimator's notify handler
+    // (the streaming thread), so no extra locking is needed.
+    guint minEncoderBitrateBps_ = 0;
+    guint maxEncoderBitrateBps_ = 0;
+    guint lastAppliedBitrateBps_ = 0;
+    std::chrono::steady_clock::time_point lastBitrateApply_;
 
     void makeElement(const ElementLabel elementLabel, const char* element);
     void onH264SinkPadAdded(GstPad* newPad);

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage: whip-mpegts [OPTION]
   --h264PacketizationMode INT (0 or 1, default=1)
   --h264Profile STRING (default=constrained-baseline)
   --h264KeyframeInterval INT (frames, default=60)
+  --congestion-control (enable sender-side GCC dynamic bitrate; no effect with --bypass-video)
 ```
 
 Flags:
@@ -51,6 +52,7 @@ Flags:
 - \--bypass-video Skip video transcoding (no decode/encode). Only works when the input video is already H264. Cannot be combined with `--vp8`.
 - \--bypass-audio Skip audio transcoding (no decode/encode). Only works when the input audio is already OPUS.
 - \--vp8 Encode video as VP8 instead of H264 (cannot be combined with `--bypass-video`).
+- \--congestion-control Enable sender-side dynamic bitrate: drive the video encoder from the GCC bandwidth estimate (see [Bandwidth estimation](#bandwidth-estimation-experimental)). Off by default. No effect with `--bypass-video` (there is no encoder to re-target).
 
 ### Recommended input codecs
 
@@ -217,18 +219,32 @@ source encoder, since on the bypass path this tool forwards them unchanged.
 
 ## Bandwidth estimation (experimental)
 
-When the send path negotiates transport-wide congestion control (TWCC), `whip-mpegts` can attach a
-Google Congestion Control (GCC) bandwidth estimator to the outgoing `webrtcbin` for the **video**
-track. The estimator (`rtpgccbwe`) consumes the TWCC feedback returned by the receiver and produces
-a continuously updated estimate of the available uplink bitrate. The estimator is seeded from the
-configured video bitrate (`-b, --h264EncodeBitrate`): minimum = 10% of the target, start = the
-target, maximum = the target (all in bits per second).
+Sender-side congestion control is **opt-in** via `--congestion-control` and is **off by default**.
+With the flag off, the encoder runs at the static `-b, --h264EncodeBitrate` target and nothing
+below applies — behaviour is unchanged.
 
-At this stage the estimate is only **logged** (throttled to about once per second) so the loop can
-be observed; it does **not** yet change the encoder bitrate — reacting to the estimate is tracked
-separately. The estimator is attached only when the `rtpgccbwe` element is present in the GStreamer
-installation; if it is missing, bandwidth estimation is skipped and behaviour is unchanged. It
-applies to the video transceiver only; the Opus audio track is out of scope.
+When enabled, and when the send path negotiates transport-wide congestion control (TWCC),
+`whip-mpegts` attaches a Google Congestion Control (GCC) bandwidth estimator to the outgoing
+`webrtcbin` for the **video** track. The estimator (`rtpgccbwe`) consumes the TWCC feedback
+returned by the receiver and produces a continuously updated estimate of the available uplink
+bitrate. The estimator is seeded from the configured video bitrate (`-b, --h264EncodeBitrate`):
+minimum = 10% of the target, start = the target, maximum = the target (all in bits per second).
+
+Each estimate update is applied to the video encoder's target bitrate. The estimate is **clamped**
+to `[10% of target, target]` so it never starves or overshoots the configured target, and updates
+are **rate-limited** to at most once per second (also skipping sub-2% changes) so the encoder is
+not thrashed by the continuously updating estimate. The unit difference between the two encoders is
+respected: it is written to `x264enc`'s `bitrate` property in **kb/s**, and to `vp8enc`'s
+`target-bitrate` property in **bits per second** (`--vp8`). The property write happens directly
+from the estimator's streaming-thread notification; this is safe because both encoder bitrate
+properties are `GST_PARAM_MUTABLE_PLAYING` (changeable at runtime) and GObject property setters are
+themselves thread-safe, so no marshalling to the main loop is needed.
+
+The estimator is attached only when the `rtpgccbwe` element is present in the GStreamer
+installation; if it is missing, congestion control is skipped and behaviour is unchanged. It
+applies to the video transceiver only; the Opus audio track is out of scope. `--congestion-control`
+has **no effect with `--bypass-video`**: the passthrough path has no encoder to re-target, so the
+flag is a documented no-op there (the estimator is not wired up and nothing is changed or crashes).
 
 ## Debugging
 

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@ enum : int
     OPT_H264_PACKETIZATION_MODE,
     OPT_H264_PROFILE,
     OPT_H264_KEYFRAME_INTERVAL,
+    OPT_CONGESTION_CONTROL,
 };
 
 ::option longOptions[] = {{"udpSourceAddress", required_argument, nullptr, 'a'},
@@ -50,6 +51,7 @@ enum : int
     {"h264PacketizationMode", required_argument, nullptr, OPT_H264_PACKETIZATION_MODE},
     {"h264Profile", required_argument, nullptr, OPT_H264_PROFILE},
     {"h264KeyframeInterval", required_argument, nullptr, OPT_H264_KEYFRAME_INTERVAL},
+    {"congestion-control", no_argument, nullptr, OPT_CONGESTION_CONTROL},
     {nullptr, no_argument, nullptr, 0}};
 
 const auto shortOptions = "a:p:u:k:d:r:o:b:m:ts";
@@ -77,7 +79,9 @@ const char* usageString = "Usage: whip-mpegts [OPTION]\n"
                           "  --vp8 (encode video as VP8 instead of H264)\n"
                           "  --h264PacketizationMode INT (H264 RTP packetization-mode, 0 or 1, default=1)\n"
                           "  --h264Profile STRING (H264 encoder profile, default=constrained-baseline)\n"
-                          "  --h264KeyframeInterval INT (x264enc key-int-max in frames, default=60)\n";
+                          "  --h264KeyframeInterval INT (x264enc key-int-max in frames, default=60)\n"
+                          "  --congestion-control (enable sender-side GCC dynamic bitrate; no effect with "
+                          "--bypass-video)\n";
 
 GMainLoop* mainLoop = nullptr;
 std::unique_ptr<Pipeline> pipeline;
@@ -192,6 +196,9 @@ int32_t main(int32_t argc, char** argv)
             break;
         case OPT_H264_KEYFRAME_INTERVAL:
             config.h264KeyframeInterval_ = std::strtoul(optarg, nullptr, 10);
+            break;
+        case OPT_CONGESTION_CONTROL:
+            config.congestionControl_ = true;
             break;
         default:
             break;


### PR DESCRIPTION
Closes #45
Closes #46

Combines the two sub-issues split from #1: #45 applies the GCC estimate to the
video encoder, and #46 gates that behind an opt-in flag. They ship together
because #46 exists specifically to keep #45's dynamic-bitrate mechanism from
being an unsafe always-on default.

## What changed

- **Config.h** — new `congestionControl_` field (default `false`) with matching `toString()` output.
- **main.cpp** — new `--congestion-control` long option (`OPT_CONGESTION_CONTROL`), added to `longOptions`, the usage string, and the parse switch.
- **Pipeline.cpp / Pipeline.h** — the rtpgccbwe estimator (wired in #44) is now attached only when `--congestion-control` is set; on each `notify::estimated-bitrate` the estimate is applied to the video encoder.
- **README.md** — usage block, flag list, and the "Bandwidth estimation" section updated to describe the opt-in behaviour and its limitations.

## Behaviour details

- **Opt-in gate (#46):** with the flag off, the estimator is not wired up at all — behaviour is byte-for-byte the pre-existing static `config.videoEncodeBitrate` path (no dynamic updates).
- **Unit difference (#45):** `x264enc` `bitrate` is set in **kb/s** (`targetBps / 1000`); `vp8enc` `target-bitrate` is set in **bps** — mirroring the existing static-config code in `Pipeline.cpp`.
- **Clamp + rate-limit:** the estimate is clamped to `[10% of target, target]` (same bounds used to seed the estimator in #44), applied at most once per second, and skips sub-2% changes to avoid thrashing the encoder.
- **Encoder-thread safety:** the `g_object_set` runs directly on the estimator's streaming-thread notify handler. This is safe without marshalling to the main loop because GObject property setters take the instance lock and both encoder bitrate properties are `GST_PARAM_MUTABLE_PLAYING` (defined as changeable at runtime while PLAYING). This is documented inline and in the README.
- **`--bypass-video`:** the passthrough path has no encoder, so the flag is a documented **no-op** — the estimator is not wired up (guarded by `!config.bypass_video_`) and a log line notes it is ignored. Nothing crashes and no bitrate is set on a non-existent element.
- **`--vp8`:** handled via the bps unit path above.
- **rtpgccbwe absent:** still degrades gracefully (estimator skipped, behaviour unchanged), as in #44.

## Test plan

- [ ] CI Docker build compiles the C++ changes (this repo cannot be built locally — no CMake/GStreamer toolchain available; **CI is the gate**).
- [ ] `--congestion-control` off: default run behaves exactly as before (static `-b`/`--h264EncodeBitrate` target; no estimator log lines).
- [ ] `--congestion-control` on (H264): encoder `bitrate` (kb/s) tracks the clamped estimate, rate-limited to ~1 Hz.
- [ ] `--congestion-control` on with `--vp8`: `target-bitrate` (bps) tracks the clamped estimate.
- [ ] `--congestion-control` with `--bypass-video`: flag is a no-op, log notes it is ignored, no crash.

**Note:** runtime behavioural validation (bitrate drop/recover under a simulated bandwidth constraint, per #45's acceptance criteria) was **NOT performed locally** because the GStreamer/CMake toolchain is not available in this environment. The reasoning above is by code inspection; the CI build is the gate, and runtime validation should be done in an environment with the full pipeline.

Co-authored-by: Claude Agent <noreply@anthropic.com>